### PR TITLE
fix: use environment variables for LLM provider selection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -430,7 +430,9 @@ program
       }
 
       spinner.text = "Inicializando LLM provider...";
-      const llmProvider = await LLMProviderFactory.createDefault();
+      const llmProvider = await LLMProviderFactory.create(
+        LLMProviderFactory.loadFromEnv()
+      );
       const responseGenerator = new ResponseGenerator(search, llmProvider);
       const sessionManager = new ChatSessionManager();
 


### PR DESCRIPTION
- Replace createDefault() with loadFromEnv() to respect VIVADOC_LLM_PROVIDER
- Allow explicit provider selection via environment variables
- Fixes issue where Ollama was always used despite OpenAI config
- Enables proper fallback chain: OpenAI > Ollama > Mock